### PR TITLE
Make safe-coloured-text-terminfo optional

### DIFF
--- a/feedback/feedback.cabal
+++ b/feedback/feedback.cabal
@@ -49,12 +49,14 @@ library
     , pretty-show
     , safe-coloured-text
     , safe-coloured-text-layout
-    , safe-coloured-text-terminfo
     , text
     , time
     , typed-process
     , unliftio
     , yaml
+  if !os(windows)
+    build-depends:
+        safe-coloured-text-terminfo
   default-language: Haskell2010
 
 executable feedback

--- a/feedback/package.yaml
+++ b/feedback/package.yaml
@@ -25,12 +25,15 @@ library:
   - pretty-show
   - safe-coloured-text
   - safe-coloured-text-layout
-  - safe-coloured-text-terminfo
   - text
   - time
   - typed-process
   - unliftio
   - yaml
+  when:
+    - condition: '!os(windows)'
+      dependencies:
+        - safe-coloured-text-terminfo
 
 executables:
   feedback:

--- a/feedback/src/Feedback/Loop.hs
+++ b/feedback/src/Feedback/Loop.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -20,7 +21,11 @@ import System.FSNotify as FS
 import System.IO (hGetChar)
 import System.Mem (performGC)
 import Text.Colour
+#if MIN_VERSION_safe_coloured_text_terminfo
 import Text.Colour.Capabilities.FromEnv (getTerminalCapabilitiesFromEnv)
+#else
+import Text.Colour.Capabilities (TerminalCapabilities(..))
+#endif
 import UnliftIO
 
 runFeedbackLoop :: IO ()
@@ -117,7 +122,11 @@ data Output
 
 outputWorker :: OutputSettings -> Chan Output -> IO ()
 outputWorker OutputSettings {..} outputChan = do
+#if MIN_VERSION_safe_coloured_text_terminfo
   terminalCapabilities <- getTerminalCapabilitiesFromEnv
+#else
+  let terminalCapabilities = WithoutColours
+#endif
   let put = putTimedChunks terminalCapabilities
   forever $ do
     event <- readChan outputChan

--- a/feedback/src/Feedback/Loop/OptParse.hs
+++ b/feedback/src/Feedback/Loop/OptParse.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -11,7 +12,11 @@ import Feedback.Common.Output
 import System.Exit
 import Text.Colour
 import Text.Colour.Layout
-import Text.Colour.Term
+#if MIN_VERSION_safe_coloured_text_terminfo
+import Text.Colour.Term (putChunks)
+#else
+import Text.Colour (putChunksWith)
+#endif
 import Text.Show.Pretty (pPrint)
 
 getLoopSettings :: IO LoopSettings
@@ -47,7 +52,12 @@ combineToSettings flags@Flags {..} environment mConf = do
           pure config
   case mLoopConfig of
     Nothing -> do
-      putChunks $ concatMap (<> ["\n"]) $ prettyConfiguration mConf
+#if MIN_VERSION_safe_coloured_text_terminfo
+      putChunks
+#else
+      putChunksWith WithoutColours
+#endif
+         $ concatMap (<> ["\n"]) $ prettyConfiguration mConf
       exitSuccess
     Just loopConfig -> do
       loopSets <-

--- a/feedback/src/Feedback/Test.hs
+++ b/feedback/src/Feedback/Test.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -10,12 +11,20 @@ import Feedback.Common.Output
 import Feedback.Common.Process
 import Feedback.Test.OptParse
 import GHC.Clock (getMonotonicTimeNSec)
+#if MIN_VERSION_safe_coloured_text_terminfo
 import Text.Colour.Capabilities.FromEnv (getTerminalCapabilitiesFromEnv)
+#else
+import Text.Colour.Capabilities (TerminalCapabilities(..))
+#endif
 
 runFeedbackTest :: IO ()
 runFeedbackTest = do
   TestSettings {..} <- getSettings
+#if MIN_VERSION_safe_coloured_text_terminfo
   terminalCapabilities <- getTerminalCapabilitiesFromEnv
+#else
+  let terminalCapabilities = WithoutColours
+#endif
   let put = putTimedChunks terminalCapabilities
   forM_ (M.toList testSettingLoops) $ \(loopName, LoopSettings {..}) -> do
     put [indicatorChunk "testing ", " ", loopNameChunk loopName]


### PR DESCRIPTION
As discussed in #5.

(Still does not work on Windows, but at least compiles out of the box)