### PR TITLE
Windows: use isMinTTY to detect terminal

### DIFF
--- a/feedback/feedback.cabal
+++ b/feedback/feedback.cabal
@@ -54,7 +54,10 @@ library
     , typed-process
     , unliftio
     , yaml
-  if !os(windows)
+  if os(windows)
+    build-depends:
+        Win32 >=2.13.2
+  else
     build-depends:
         safe-coloured-text-terminfo
   default-language: Haskell2010

--- a/feedback/package.yaml
+++ b/feedback/package.yaml
@@ -31,7 +31,11 @@ library:
   - unliftio
   - yaml
   when:
-    - condition: '!os(windows)'
+  - condition: os(windows)
+    then:
+      dependencies:
+        - Win32 >= 2.13.2
+    else:
       dependencies:
         - safe-coloured-text-terminfo
 

--- a/feedback/src/Feedback/Loop.hs
+++ b/feedback/src/Feedback/Loop.hs
@@ -25,7 +25,7 @@ import System.Win32.MinTTY (isMinTTYHandle)
 import System.Win32.Types (withHandleToHANDLE)
 #endif
 import Text.Colour
-#if MIN_VERSION_safe_coloured_text_terminfo(0,0,0)
+#ifdef MIN_VERSION_safe_coloured_text_terminfo
 import Text.Colour.Capabilities.FromEnv (getTerminalCapabilitiesFromEnv)
 #else
 import Text.Colour.Capabilities (TerminalCapabilities(..))
@@ -160,7 +160,7 @@ outputWorker OutputSettings {..} outputChan = do
         put $ durationChunks nanosecs
   where
 
-#if MIN_VERSION_safe_coloured_text_terminfo(0,0,0)
+#ifdef MIN_VERSION_safe_coloured_text_terminfo
     getTermCaps = getTerminalCapabilitiesFromEnv
 #else
     getTermCaps = pure WithoutColours

--- a/feedback/src/Feedback/Loop.hs
+++ b/feedback/src/Feedback/Loop.hs
@@ -107,11 +107,7 @@ processWorker runSettings eventChan outputChan = do
 waitForEvent :: Chan FS.Event -> IO RestartEvent
 waitForEvent eventChan = do
   isTerminal <- hIsTerminalDevice stdin
-#ifdef MIN_VERSION_Win32
-  isMinTTY <- withHandleToHANDLE stdin isMinTTYHandle
-#else
-  let isMinTTY = False
-#endif
+  isMinTTY <- getMinTTY
   if isTerminal || isMinTTY
     then do
       hSetBuffering stdin NoBuffering
@@ -120,6 +116,12 @@ waitForEvent eventChan = do
           (StdinEvent <$> hGetChar stdin)
           (FSEvent <$> readChan eventChan)
     else FSEvent <$> readChan eventChan
+  where
+#ifdef MIN_VERSION_Win32
+      getMinTTY = withHandleToHANDLE stdin isMinTTYHandle
+#else
+      getMinTTY = pure False
+#endif
 
 data Output
   = OutputEvent !RestartEvent

--- a/feedback/src/Feedback/Loop/Filter.hs
+++ b/feedback/src/Feedback/Loop/Filter.hs
@@ -29,16 +29,18 @@ import UnliftIO
 getStdinFiles :: Path Abs Dir -> IO (Maybe (Set FilePath))
 getStdinFiles here = do
   isTerminal <- hIsTerminalDevice stdin
-#ifdef MIN_VERSION_Win32
-  isMinTTY <- withHandleToHANDLE stdin isMinTTYHandle
-#else
-  let isMinTTY = False
-#endif
+  isMinTTY <- getMinTTY
   if isTerminal || isMinTTY
     then pure Nothing
     else
       (Just <$> handleFileSet here stdin)
         `catch` (\(_ :: IOException) -> pure Nothing)
+  where
+#ifdef MIN_VERSION_Win32
+      getMinTTY = withHandleToHANDLE stdin isMinTTYHandle
+#else
+      getMinTTY = pure False
+#endif
 
 mkEventFilter :: Path Abs Dir -> Maybe (Set FilePath) -> FilterSettings -> IO (FS.Event -> Bool)
 mkEventFilter here mStdinFiles FilterSettings {..} = do

--- a/feedback/src/Feedback/Loop/Filter.hs
+++ b/feedback/src/Feedback/Loop/Filter.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -19,12 +20,21 @@ import Path.IO
 import System.Exit
 import System.FSNotify as FS
 import System.Process.Typed as Typed
+#ifdef MIN_VERSION_Win32
+import System.Win32.MinTTY (isMinTTYHandle)
+import System.Win32.Types (withHandleToHANDLE)
+#endif
 import UnliftIO
 
 getStdinFiles :: Path Abs Dir -> IO (Maybe (Set FilePath))
 getStdinFiles here = do
   isTerminal <- hIsTerminalDevice stdin
-  if isTerminal
+#ifdef MIN_VERSION_Win32
+  isMinTTY <- withHandleToHANDLE stdin isMinTTYHandle
+#else
+  let isMinTTY = False
+#endif
+  if isTerminal || isMinTTY
     then pure Nothing
     else
       (Just <$> handleFileSet here stdin)

--- a/feedback/src/Feedback/Loop/OptParse.hs
+++ b/feedback/src/Feedback/Loop/OptParse.hs
@@ -12,7 +12,7 @@ import Feedback.Common.Output
 import System.Exit
 import Text.Colour
 import Text.Colour.Layout
-#if MIN_VERSION_safe_coloured_text_terminfo(0,0,0)
+#ifdef MIN_VERSION_safe_coloured_text_terminfo
 import Text.Colour.Term (putChunks)
 #endif
 import Text.Show.Pretty (pPrint)
@@ -63,7 +63,7 @@ combineToSettings flags@Flags {..} environment mConf = do
       pure loopSets
   where
 
-#if MIN_VERSION_safe_coloured_text_terminfo(0,0,0)
+#ifdef MIN_VERSION_safe_coloured_text_terminfo
     put = putChunks
 #else
     put = putChunksWith WithoutColours

--- a/feedback/src/Feedback/Test.hs
+++ b/feedback/src/Feedback/Test.hs
@@ -12,7 +12,7 @@ import Feedback.Common.Process
 import Feedback.Test.OptParse
 import GHC.Clock (getMonotonicTimeNSec)
 
-#if MIN_VERSION_safe_coloured_text_terminfo(0,0,0)
+#ifdef MIN_VERSION_safe_coloured_text_terminfo
 import Text.Colour.Capabilities.FromEnv (getTerminalCapabilitiesFromEnv)
 #else
 import Text.Colour.Capabilities (TerminalCapabilities(..))
@@ -34,7 +34,7 @@ runFeedbackTest = do
     put $ durationChunks duration
   where
 
-#if MIN_VERSION_safe_coloured_text_terminfo(0,0,0)
+#ifdef MIN_VERSION_safe_coloured_text_terminfo
     getTermCaps = getTerminalCapabilitiesFromEnv
 #else
     getTermCaps = WithoutColours

--- a/feedback/src/Feedback/Test.hs
+++ b/feedback/src/Feedback/Test.hs
@@ -37,5 +37,5 @@ runFeedbackTest = do
 #ifdef MIN_VERSION_safe_coloured_text_terminfo
     getTermCaps = getTerminalCapabilitiesFromEnv
 #else
-    getTermCaps = WithoutColours
+    getTermCaps = pure WithoutColours
 #endif


### PR DESCRIPTION
Continuing work towards #5.

See https://hackage.haskell.org/package/ansi-terminal-0.11.3/docs/System-Console-ANSI.html#v:hSupportsANSI for the explanation of this Windows peculiarity.

`Win32 >= 2.13.2` is a bit ambitious (see https://github.com/haskell/process/pull/246), but according to the [changelog](https://hackage.haskell.org/package/Win32-2.13.2.0/changelog) we do need the very latest release for MinTTY features. 

With this patch `feedback --help` succeeds, but everything else freezes. Stay tuned.