### PR TITLE
Provide a default.nix using flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -17,6 +17,22 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667077288,
@@ -84,6 +100,7 @@
     "root": {
       "inputs": {
         "autodocodec": "autodocodec",
+        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks",
         "safe-coloured-text": "safe-coloured-text",

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,8 @@
     safe-coloured-text.flake = false;
     sydtest.url = "github:NorfairKing/sydtest?ref=flake";
     sydtest.flake = false;
+    flake-compat.url = "github:edolstra/flake-compat";
+    flake-compat.flake = false;
   };
 
   outputs =
@@ -26,6 +28,7 @@
     , safe-coloured-text
     , sydtest
     , autodocodec
+    , flake-compat
     }:
     let
       system = "x86_64-linux";


### PR DESCRIPTION
**summary**
This small PR adds a default.nix using [flake-compat](https://github.com/edolstra/flake-compat) to allow for using/building feedback without flakes: `nix-build` will just build the default package, which of course is the feedback derivation.

**motivation**
I avoid using nix flakes but wanted to give `feedback` a try and `flake-compat` makes that pretty straight forward. If you prefer to not provide/maintain this - that's fair. I just thought this might be useful to others as well so I created this small PR ;)