### PR TITLE
Corrected install instructions for flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Add this to your system flake:
 ``` nix
 {
   inputs = {
-    feedback.url = "github:NorfairKing/feedback?ref=flake";
+    feedback.url = "github:NorfairKing/feedback";
   };
   outputs = { nixpkgs, feedback, ... }:
     let system = "x86_64-linux";


### PR DESCRIPTION
With the old url I got the error

```
error: unable to download 'https://api.github.com/repos/NorfairKing/feedback/commits/flake': HTTP error 422

       response body:

       {
         "message": "No commit found for SHA: flake",
         "documentation_url": "https://docs.github.com/rest/commits/commits#get-a-commit"
       }
```

Removing the ref fixes it.