### PR TITLE
Use flake-parts to unlock all the architectures

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,6 +33,24 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1683560683,
+        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667077288,
@@ -60,6 +78,24 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -101,6 +137,7 @@
       "inputs": {
         "autodocodec": "autodocodec",
         "dekking": "dekking",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks",
         "safe-coloured-text": "safe-coloured-text",

--- a/flake.nix
+++ b/flake.nix
@@ -6,89 +6,98 @@
   };
 
   inputs = {
+    autodocodec.flake = false;
+    autodocodec.url = "github:NorfairKing/autodocodec?ref=flake";
+    dekking.flake = false;
+    dekking.url = "github:NorfairKing/dekking";
+    flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-22.05";
     pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
-    validity.url = "github:NorfairKing/validity?ref=flake";
-    validity.flake = false;
-    autodocodec.url = "github:NorfairKing/autodocodec?ref=flake";
-    autodocodec.flake = false;
-    safe-coloured-text.url = "github:NorfairKing/safe-coloured-text?ref=flake";
     safe-coloured-text.flake = false;
-    sydtest.url = "github:NorfairKing/sydtest?ref=flake";
+    safe-coloured-text.url = "github:NorfairKing/safe-coloured-text?ref=flake";
     sydtest.flake = false;
-    dekking.url = "github:NorfairKing/dekking";
-    dekking.flake = false;
+    sydtest.url = "github:NorfairKing/sydtest?ref=flake";
+    validity.flake = false;
+    validity.url = "github:NorfairKing/validity?ref=flake";
   };
 
   outputs =
     { self
-    , nixpkgs
-    , pre-commit-hooks
-    , validity
-    , safe-coloured-text
-    , sydtest
     , autodocodec
     , dekking
-    }:
-    let
-      system = "x86_64-linux";
-      pkgsFor = nixpkgs: import nixpkgs {
-        inherit system;
-        config.allowUnfree = true;
-        overlays = [
-          self.overlays.${system}
-          (import (autodocodec + "/nix/overlay.nix"))
-          (import (safe-coloured-text + "/nix/overlay.nix"))
-          (import (sydtest + "/nix/overlay.nix"))
-          (import (validity + "/nix/overlay.nix"))
-          (import (dekking + "/nix/overlay.nix"))
-        ];
+    , flake-parts
+    , nixpkgs
+    , pre-commit-hooks
+    , safe-coloured-text
+    , sydtest
+    , validity
+    }@inputs: flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      flake = {
+        overlays.default = import ./nix/overlay.nix;
       };
-      pkgs = pkgsFor nixpkgs;
-
-    in
-    {
-      overlays.${system} = import ./nix/overlay.nix;
-      packages.${system}.default = pkgs.feedback;
-      checks.${system} = {
-        package = self.packages.${system}.default;
-        shell = self.devShells.${system}.default;
-        coverage-report = pkgs.dekking.makeCoverageReport {
-          name = "test-coverage-report";
-          coverables = [ "feedback" ];
-          coverage = [ "feedback-test-harness" ];
-        };
-        pre-commit = pre-commit-hooks.lib.${system}.run {
-          src = ./.;
-          hooks = {
-            hlint.enable = true;
-            hpack.enable = true;
-            ormolu.enable = true;
-            nixpkgs-fmt.enable = true;
-            nixpkgs-fmt.excludes = [ ".*/default.nix" ];
-            cabal2nix.enable = true;
+      perSystem = { config, pkgs, lib, system, ... }:
+        let
+          pkgs' = import nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
+            overlays = [
+              self.overlays.default
+              (import (autodocodec + "/nix/overlay.nix"))
+              (import (safe-coloured-text + "/nix/overlay.nix"))
+              (import (sydtest + "/nix/overlay.nix"))
+              (import (validity + "/nix/overlay.nix"))
+              (import (dekking + "/nix/overlay.nix"))
+            ];
+          };
+        in
+        {
+          packages.default = pkgs'.feedback;
+          checks = {
+            package = config.packages.default;
+            shell = config.devShells.default;
+            coverage-report = pkgs'.dekking.makeCoverageReport {
+              name = "test-coverage-report";
+              coverables = [ "feedback" ];
+              coverage = [ "feedback-test-harness" ];
+            };
+            pre-commit = pre-commit-hooks.lib.${system}.run {
+              src = ./.;
+              hooks = {
+                hlint.enable = true;
+                hpack.enable = true;
+                ormolu.enable = true;
+                nixpkgs-fmt.enable = true;
+                nixpkgs-fmt.excludes = [ ".*/default.nix" ];
+                cabal2nix.enable = true;
+              };
+            };
+          };
+          devShells.default = pkgs'.haskellPackages.shellFor {
+            name = "feedback-shell";
+            packages = p: [ p.feedback p.feedback-test-harness ];
+            withHoogle = true;
+            doBenchmark = true;
+            buildInputs = (with pkgs'; [
+              feedback
+              niv
+              zlib
+              cabal-install
+            ]) ++ (with pre-commit-hooks.packages.${system};
+              [
+                hlint
+                hpack
+                nixpkgs-fmt
+                ormolu
+                cabal2nix
+              ]);
+            shellHook = self.checks.${system}.pre-commit.shellHook + pkgs'.feedback.shellHook;
           };
         };
-      };
-      devShells.${system}.default = pkgs.haskellPackages.shellFor {
-        name = "feedback-shell";
-        packages = p: [ p.feedback p.feedback-test-harness ];
-        withHoogle = true;
-        doBenchmark = true;
-        buildInputs = (with pkgs; [
-          feedback
-          niv
-          zlib
-          cabal-install
-        ]) ++ (with pre-commit-hooks.packages.${system};
-          [
-            hlint
-            hpack
-            nixpkgs-fmt
-            ormolu
-            cabal2nix
-          ]);
-        shellHook = self.checks.${system}.pre-commit.shellHook + pkgs.feedback.shellHook;
-      };
     };
 }


### PR DESCRIPTION
This has a similar background like #15.
My colleagues who run macOS machines need support for that arch, and also I have seen that some gitlab action runners run on ARM, so the lack of ARM linux builds is a bit annoying, too.

This PR uses flake-parts which is an elegant way to unlock all the archs.