### PR TITLE
Add ability to define custom filter

### DIFF
--- a/feedback/src/Feedback/Common/OptParse.hs
+++ b/feedback/src/Feedback/Common/OptParse.hs
@@ -59,7 +59,8 @@ combineToRunSettings RunConfiguration {..} = do
 
 data FilterSettings = FilterSettings
   { filterSettingGitignore :: !Bool,
-    filterSettingFind :: !(Maybe String)
+    filterSettingFind :: !(Maybe String),
+    filterSettingCustom :: !(Maybe String)
   }
   deriving (Show, Eq, Generic)
 
@@ -67,6 +68,7 @@ combineToFilterSettings :: FilterConfiguration -> FilterSettings
 combineToFilterSettings FilterConfiguration {..} =
   let filterSettingGitignore = fromMaybe True filterConfigGitignore
       filterSettingFind = filterConfigFind
+      filterSettingCustom = filterConfigCustom
    in FilterSettings {..}
 
 data OutputSettings = OutputSettings
@@ -232,7 +234,8 @@ makeRunConfiguration c =
 
 data FilterConfiguration = FilterConfiguration
   { filterConfigGitignore :: !(Maybe Bool),
-    filterConfigFind :: !(Maybe String)
+    filterConfigFind :: !(Maybe String),
+    filterConfigCustom :: !(Maybe String)
   }
   deriving stock (Show, Eq, Generic)
   deriving (FromJSON, ToJSON) via (Autodocodec FilterConfiguration)
@@ -258,12 +261,15 @@ filterConfigurationObjectCodec =
       .= filterConfigGitignore
     <*> optionalField "find" "arguments for the 'find' command to find files to be notified about"
       .= filterConfigFind
+    <*> optionalField "custom" "custom command and it's arguments"
+      .= filterConfigCustom
 
 emptyFilterConfiguration :: FilterConfiguration
 emptyFilterConfiguration =
   FilterConfiguration
     { filterConfigGitignore = Nothing,
-      filterConfigFind = Nothing
+      filterConfigFind = Nothing,
+      filterConfigCustom = Nothing
     }
 
 data OutputConfiguration = OutputConfiguration


### PR DESCRIPTION
I found it useful to use something else than `find` command (e.g. [fd](https://github.com/sharkdp/fd)). This PR adds the ability to specify a custom command in the `filter` field in `feedback.yaml` file